### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server that connects an LLM to the archives (since 1999) of [The Guardian](https://www.theguardian.com/), including the full text of all articles — more than 1.9 million of them. Useful for real-time headlines, journalism analysis, and historical research.
 
+<a href="https://glama.ai/mcp/servers/@jbenton/guardian-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jbenton/guardian-mcp-server/badge" alt="guardian-mcp-server MCP server" />
+</a>
+
 ## Installation
 
 **A [Guardian Open Platform](https://open-platform.theguardian.com/) API key is required.** You can get one here: https://open-platform.theguardian.com/access/


### PR DESCRIPTION
This PR adds a badge for the [guardian-mcp-server](https://glama.ai/mcp/servers/@jbenton/guardian-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@jbenton/guardian-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jbenton/guardian-mcp-server/badge" alt="guardian-mcp-server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.